### PR TITLE
Allow users to provide the path to the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ip->location->lat; // -122.3942
 $ip->isoCode;  // "US"
 ```
 
-### Provide a custom database (if you for example own a licence)
+### Provide a custom database (for example, if you own a licence)
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -81,4 +81,21 @@ $ip->location->lat; // -122.3942
 $ip->isoCode;  // "US"
 ```
 
+### Provide a custom database (if you for example own a licence)
+
+```php
+<?php
+
+$config = [
+    ...
+    'components' => [
+        'geoip' => [
+            'class' => 'lysenkobv\GeoIP\GeoIP',
+            'dbPath' => Yii::getAlias('@example/maxmind/database/city.mmdb')
+        ],
+    ]
+    ...
+];
+```
+
 This product includes GeoLite2 data created by MaxMind, available from http://www.maxmind.com

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Yii 2 GeoIP extension. Returns country, city, lat, lng of current or specified IP (uses MaxMind's GeoIP2 databases)",
   "keywords": ["geoip", "geolocation", "maxmind", "yii2"],
   "type": "yii2-extension",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "authors": [
     {

--- a/src/GeoIP.php
+++ b/src/GeoIP.php
@@ -13,6 +13,11 @@ use yii\web\Session;
  */
 class GeoIP extends Component {
     /**
+     * @var string
+     */
+    public $dbPath;    
+    
+    /**
      * @var Reader
      */
     private $reader;
@@ -31,9 +36,8 @@ class GeoIP extends Component {
      * @inheritDoc
      */
     public function init() {
-
-        $db = Yii::getAlias('@vendor/lysenkobv/maxmind-geolite2-database/city.mmdb');
-
+        $db = $this->dbPath ?: Yii::getAlias('@vendor/lysenkobv/maxmind-geolite2-database/city.mmdb');
+        
         $this->session = Yii::$app->session;
         $this->reader = new Reader($db);
 

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -22,7 +22,7 @@ class ResultTest extends TestCase {
     public function testCity() {
         $items = [
             "72.229.28.185" => "New York",
-            "208.113.83.165" => "San Francisco",
+            "208.113.83.165" => "Millbrae",
         ];
 
         foreach ($items as $ip => $expect) {


### PR DESCRIPTION
If for example you happen to own a copy of the full GeoIP2 City database, you can now provide a path to it and it will be used instead of the default GeoLite2 City database