### PR TITLE
Added missing phpdoc property

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -10,6 +10,7 @@ namespace lysenkobv\GeoIP;
  * @property string|null city
  * @property string|null country
  * @property Location location
+ * @property string|null isoCode
  */
 class Result extends ResultBase {
     protected function getCity($data) {

--- a/src/Result.php
+++ b/src/Result.php
@@ -13,7 +13,7 @@ namespace lysenkobv\GeoIP;
  * @property string|null $isoCode
  */
 class Result extends ResultBase {
-    protected function getCity($data) {
+    public function getCity($data) {
         $value = null;
 
         if (isset($data['city']['names']['en'])) {
@@ -23,7 +23,7 @@ class Result extends ResultBase {
         return $value;
     }
 
-    protected function getCountry($data) {
+    public function getCountry($data) {
         $value = null;
 
         if (isset($data['country']['names']['en'])) {
@@ -33,7 +33,7 @@ class Result extends ResultBase {
         return $value;
     }
 
-    protected function getLocation($data) {
+    public function getLocation($data) {
         $value = new Location();
 
         if (isset($data['location'])) {
@@ -45,7 +45,7 @@ class Result extends ResultBase {
         return $value;
     }
 
-    protected function getIsoCode($data) {
+    public function getIsoCode($data) {
         $value = null;
 
         if (isset($data['country']['iso_code'])) {

--- a/src/Result.php
+++ b/src/Result.php
@@ -7,10 +7,10 @@ namespace lysenkobv\GeoIP;
  * Class Result
  * @package lysenkobv\GeoIP
  *
- * @property string|null city
- * @property string|null country
- * @property Location location
- * @property string|null isoCode
+ * @property string|null $city
+ * @property string|null $country
+ * @property Location $location
+ * @property string|null $isoCode
  */
 class Result extends ResultBase {
     protected function getCity($data) {


### PR DESCRIPTION
IDE did not show support for the getIsoCode method so I found out it's because it is missing from the Result class.

I would also suggest you change the getCity/getLocation/getIsoCode methods to be public, I don't see any value in keeping them hidden.

If you think it's better to keep it protected, I can revert the last commit and just add the new phpdoc property tag.